### PR TITLE
feat: add generic bump-formula workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,25 @@
+# Bump formula workflow
+
+`repository_dispatch` で formula のバージョン更新 PR を自動作成するワークフロー。
+
+## 設定
+
+`.github/bump-formulae.json` にサポートする formula を登録する。
+
+## 呼び出し方
+
+ソースリポジトリの release 時に以下を実行:
+
+```bash
+gh api repos/masa0221/homebrew-tap/dispatches \
+  -f event_type=bump-formula \
+  -f client_payload='{"formula":"mov2mp4","version":"v0.1.1"}'
+```
+
+`client_payload`:
+- `formula`: 公式名（例: mov2mp4, oauth2-dev-tool, fkds）
+- `version`: タグ名（例: v0.1.1）
+
+## 認証
+
+他リポジトリから `repository_dispatch` を叩くには PAT が必要。`HOMEBREW_TAP_TOKEN` などの Secret に設定して使用。

--- a/.github/bump-formulae.json
+++ b/.github/bump-formulae.json
@@ -1,0 +1,14 @@
+{
+  "mov2mp4": {
+    "repo": "masa0221/mov2mp4",
+    "url_type": "archive"
+  },
+  "oauth2-dev-tool": {
+    "repo": "masa0221/oauth2-dev-tool",
+    "url_type": "archive"
+  },
+  "fkds": {
+    "repo": "masa0221/fkds",
+    "url_type": "archive"
+  }
+}

--- a/.github/workflows/bump-formula.yml
+++ b/.github/workflows/bump-formula.yml
@@ -1,0 +1,114 @@
+name: Bump formula
+
+on:
+  repository_dispatch:
+    types: [bump-formula]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v4
+
+      - name: Parse payload
+        id: payload
+        run: |
+          FORMULA="${{ github.event.client_payload.formula }}"
+          VERSION="${{ github.event.client_payload.version }}"
+          if [ -z "$FORMULA" ] || [ -z "$VERSION" ]; then
+            echo "Error: formula and version are required in client_payload"
+            exit 1
+          fi
+          echo "formula=${FORMULA}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Formula: ${FORMULA}, Version: ${VERSION}"
+
+      - name: Load formula config
+        id: config
+        run: |
+          FORMULA="${{ steps.payload.outputs.formula }}"
+          REPO=$(jq -r --arg f "$FORMULA" '.[$f].repo // empty' .github/bump-formulae.json)
+          URL_TYPE=$(jq -r --arg f "$FORMULA" '.[$f].url_type // "archive"' .github/bump-formulae.json)
+          if [ -z "$REPO" ]; then
+            echo "Error: formula '${FORMULA}' not found in .github/bump-formulae.json"
+            exit 1
+          fi
+          echo "repo=${REPO}" >> $GITHUB_OUTPUT
+          echo "url_type=${URL_TYPE}" >> $GITHUB_OUTPUT
+          echo "Repo: ${REPO}, URL type: ${URL_TYPE}"
+
+      - name: Get sha256 and update formula
+        id: update
+        run: |
+          FORMULA="${{ steps.payload.outputs.formula }}"
+          VERSION="${{ steps.payload.outputs.version }}"
+          REPO="${{ steps.config.outputs.repo }}"
+          URL_TYPE="${{ steps.config.outputs.url_type }}"
+          FORMULA_FILE="Formula/${FORMULA}.rb"
+
+          if [ ! -f "$FORMULA_FILE" ]; then
+            echo "Error: Formula file ${FORMULA_FILE} not found"
+            exit 1
+          fi
+
+          if [ "$URL_TYPE" = "archive" ]; then
+            URL="https://github.com/${REPO}/archive/refs/tags/${VERSION}.tar.gz"
+            echo "Fetching sha256 for ${URL}"
+            SHA=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+          else
+            echo "Error: url_type '${URL_TYPE}' not supported"
+            exit 1
+          fi
+
+          echo "New URL: ${URL}"
+          echo "New sha256: ${SHA}"
+
+          # Backup and update
+          sed -i.bak \
+            -e "s|url \"https://github.com/${REPO}/archive/refs/tags/[^\"]*\"|url \"${URL}\"|" \
+            -e "s|sha256 \"[a-f0-9]*\"|sha256 \"${SHA}\"|" \
+            "$FORMULA_FILE"
+          rm -f "${FORMULA_FILE}.bak"
+
+          # Check if anything changed
+          if git diff --quiet "$FORMULA_FILE"; then
+            echo "no_change=true" >> $GITHUB_OUTPUT
+            echo "No changes - formula may already be at this version"
+          else
+            echo "no_change=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create branch and PR
+        if: steps.update.outputs.no_change != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FORMULA="${{ steps.payload.outputs.formula }}"
+          VERSION="${{ steps.payload.outputs.version }}"
+          BRANCH="bump-${FORMULA}-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add "Formula/${FORMULA}.rb"
+          git commit -m "Bump ${FORMULA} to ${VERSION}"
+          git push -u origin "${BRANCH}"
+
+          # Check for existing PR
+          EXISTING=$(gh pr list --head "${BRANCH}" --state open --json number -q '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "PR already exists: #${EXISTING}"
+            gh pr view "$EXISTING" --web
+          else
+            gh pr create --fill \
+              --title "Bump ${FORMULA} to ${VERSION}" \
+              --body "Automated bump from release. Triggered via repository_dispatch."
+          fi
+
+      - name: Skip (no changes)
+        if: steps.update.outputs.no_change == 'true'
+        run: echo "Skipped - formula already at requested version"


### PR DESCRIPTION
## 概要
`repository_dispatch` で formula のバージョン更新 PR を自動作成する汎用ワークフローを追加。

## 追加ファイル
- `.github/workflows/bump-formula.yml` - メインのワークフロー
- `.github/bump-formulae.json` - サポートする formula の設定（mov2mp4, oauth2-dev-tool, fkds）
- `.github/README.md` - 使い方の説明

## 呼び出し例
```bash
gh api repos/masa0221/homebrew-tap/dispatches \
  -f event_type=bump-formula \
  -f client_payload='{"formula":"mov2mp4","version":"v0.1.1"}'
```

## フロー
1. ソースリポジトリが release 時に dispatch を送信
2. このワークフローが formula を更新して PR を作成
3. 既存の tests.yml で CI が実行
4. pr-pull ラベルで bottle マージ

Made with [Cursor](https://cursor.com)